### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills using GitHub, as part of the GitHub Certifications program",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary

Adds the **GitHub Skills** activity to the extracurricular offerings, as announced by the principal.

## Changes

- Added "GitHub Skills" to the `activities` dictionary in `src/app.py`
  - **Description:** Learn practical coding and collaboration skills using GitHub, as part of the GitHub Certifications program
  - **Schedule:** Mondays and Wednesdays, 3:30 PM - 4:30 PM
  - **Max participants:** 25

## Closes

Closes #6